### PR TITLE
build: Update jscs and use new "wikimedia" preset

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,24 +1,3 @@
 {
-	"requireCurlyBraces": ["if", "else", "for", "while", "do"],
-	"requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "function"],
-	"requireSpacesInFunctionExpression": {
-		"beforeOpeningCurlyBrace": true
-	},
-	"requireMultipleVarDecl": true,
-	"disallowQuotedKeysInObjects": true,
-	"requireSpacesInsideObjectBrackets": "all",
-	"disallowSpaceAfterObjectKeys": true,
-	"disallowLeftStickedOperators": ["?", "+", "/", "*", "-", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-	"disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
-	"requireRightStickedOperators": ["!"],
-	"requireLeftStickedOperators": [","],
-	"disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
-	"disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
-	"requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
-	"requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
-	"disallowKeywords": [ "with" ],
-	"disallowMultipleLineBreaks": true,
-	"validateLineBreaks": "LF",
-	"disallowKeywordsOnNewLine": ["else"],
-	"requireLineFeedAtFileEnd": true
+	"preset": "wikimedia"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function ( grunt ) {
 		jshint: {
 			options: JSON.parse( grunt.file.read( '.jshintrc' )
 				.replace( /\/\*(?:(?!\*\/)[\s\S])*\*\//g, '' ).replace( /\/\/[^\n\r]*/g, '' ) ),
-			all: ['*.js', '{tasks,test}/**/*.js']
+			all: [ '*.js', '{tasks,test}/**/*.js' ]
 		},
 		jscs: {
 			src: '<%= jshint.all %>'
@@ -37,11 +37,11 @@ module.exports = function ( grunt ) {
 			}
 		},
 		watch: {
-			files: ['<%= jshint.all %>', '.{jshintrc,jshintignore}'],
-			tasks: ['test']
+			files: [ '<%= jshint.all %>', '.{jshintrc,jshintignore}' ],
+			tasks: [ 'test' ]
 		}
 	} );
 
-	grunt.registerTask( 'test', ['jshint', 'jscs', 'banana'] );
+	grunt.registerTask( 'test', [ 'jshint', 'jscs', 'banana' ] );
 	grunt.registerTask( 'default', 'test' );
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "grunt": "0.4.2",
     "grunt-contrib-jshint": "0.8.0",
     "grunt-contrib-watch": "0.5.3",
-    "grunt-jscs-checker": "0.4.1"
+    "grunt-jscs-checker": "0.6.0"
   }
 }


### PR DESCRIPTION
Our coding style has been upstreamed and first released
in node-jscs v1.5.0 (grunt-jscs-checker v0.6.0).
