### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-banana-checker",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A grunt checker for the \"banana\" JSON i18n system provided by MediaWiki and jquery.i18n",
   "scripts": {
     "test": "grunt test"
@@ -22,7 +22,7 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
-    "grunt-contrib-jshint": "0.11.2",
+    "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-watch": "0.6.1",
     "grunt-jscs": "2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-banana-checker",
-  "version": "0.4.1",
+  "version": "0.4.0",
   "description": "A grunt checker for the \"banana\" JSON i18n system provided by MediaWiki and jquery.i18n",
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
This updates grunt-contrib-jshint to 1.11.3 since 1.11.2 was using the very latest jshint version which introduced regressions in there latest 2.9 update.