### PR TITLE
Allow skipping keys that don't have message documentation (fixes #54)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,15 @@ module.exports = function ( grunt ) {
 				options: {
 					requireMetadata: false
 				}
+			},
+			skipIncompleteMessageDocumentation: {
+				src: 'test/skipIncompleteMessageDocumentation',
+				options: {
+					skipIncompleteMessageDocumentation: [
+						'third-message-key',
+						'fourth-message-key'
+					]
+				}
 			}
 		},
 		watch: {

--- a/tasks/banana.js
+++ b/tasks/banana.js
@@ -22,7 +22,9 @@ module.exports = function ( grunt ) {
 				disallowUnusedTranslations: false,
 
 				requireCompleteTranslationLanguages: [],
-				requireCompleteTranslationMessages: []
+				requireCompleteTranslationMessages: [],
+
+				skipIncompleteMessageDocumentation: []
 			} ),
 			messageCount = 0;
 
@@ -158,6 +160,10 @@ module.exports = function ( grunt ) {
 			}
 
 			if ( options.requireCompleteMessageDocumentation ) {
+				// Filter out any missing message that is OK to be skipped
+				sourceMessageMissing = sourceMessageMissing.filter( function ( value ) {
+					return options.skipIncompleteMessageDocumentation.indexOf( value ) === -1;
+				} );
 				count = sourceMessageMissing.length;
 				if ( count > 0 ) {
 					ok = false;

--- a/test/skipIncompleteMessageDocumentation/en.json
+++ b/test/skipIncompleteMessageDocumentation/en.json
@@ -1,0 +1,9 @@
+{
+	"@metadata": {
+		"metadata-key": "metadata value"
+	},
+	"first-message-key": "first message value",
+	"second-message-key": "second message value",
+	"third-message-key": "third message value",
+	"fourth-message-key": "fourth message value"
+}

--- a/test/skipIncompleteMessageDocumentation/qqq.json
+++ b/test/skipIncompleteMessageDocumentation/qqq.json
@@ -1,0 +1,8 @@
+{
+	"@metadata": {
+		"first-metadata-key": "metadata value",
+		"second-metadata-key": "metadata value"
+	},
+	"first-message-key": "first message definition",
+	"second-message-key": "second message definition"
+}


### PR DESCRIPTION
This would allow us to enable banana-checker on repositories that are
currently not fully documented, ensuring that we don't regress any
further when new messages are added, and can gradually come into proper
compliance.

A list of messages that should be skipped from checking can be specified
in the Gruntfile.js with the "skipIncompleteMessageDocumentation"
option.

Tests included.